### PR TITLE
feat: Additional package, build, and custom Akorda handling

### DIFF
--- a/config/webpack-plugins/rebuild-ckeditor-plugins.js
+++ b/config/webpack-plugins/rebuild-ckeditor-plugins.js
@@ -35,7 +35,7 @@ class BuildCKEditorPlugins {
       const rebuild = Object.keys(changedTimes).some(isNotCKEditorPluginJS);
 
       if (rebuild) {
-        buildPlugins().then(callback);
+        buildPlugins('development').then(callback);
       } else {
         callback();
       }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -436,7 +436,7 @@ module.exports = function(webpackEnv) {
             dot: true,
           },
           to: '',
-          ignore: ['*.ts'],
+          ignore: isEnvProduction ? ['*.ts'] : [], // don't ignore typescript files during dev since it prevents auto reload
           transformPath(targetPath, absolutePath) {
             return targetPath.replace('src/plugins/lite', isEnvDevelopment ? 'ckeditor/plugins/liter' : 'liter');
           },

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -418,16 +418,27 @@ module.exports = function(webpackEnv) {
           },
         },
       ]) : null,
+      // Copy the package.json file to dist folder so we can package the module from there
+      new CopyWebpackPlugin([
+        {
+          from: {
+            glob: path.resolve(__dirname, '../package.json'),
+            dot: true,
+          },
+          to: '',
+        },
+      ]),
       // Copy additional CKEditor plugins and overrides from src
       new CopyWebpackPlugin([
         {
           from: {
-            glob: path.resolve(__dirname, '../src/plugins/**/*'),
+            glob: path.resolve(__dirname, '../src/plugins/lite/**/*'),
             dot: true,
           },
           to: '',
+          ignore: ['*.ts'],
           transformPath(targetPath, absolutePath) {
-            return targetPath.replace('src/plugins', isEnvDevelopment ? 'ckeditor/plugins' : 'plugins');
+            return targetPath.replace('src/plugins/lite', isEnvDevelopment ? 'ckeditor/plugins/liter' : 'liter');
           },
           force: true, // overwrite any existing files in the destination (e.g., so that contents.css replaces the one at dest)
         },

--- a/config/webpack.plugins.config.js
+++ b/config/webpack.plugins.config.js
@@ -5,14 +5,14 @@ const chalk = require('react-dev-utils/chalk');
 
 const pluginConfigs = [];
 
-function createPluginConfig(pluginFile) {
+function createPluginConfig(pluginFile, mode = 'production') {
   return {
     entry: pluginFile,
     output: {
       path: pluginFile.replace('/plugin.ts', ''),
       filename: 'plugin.js',
     },
-    mode: 'production',
+    mode,
     resolve: {
       // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
       extensions: ['.ts', '.js'],
@@ -54,13 +54,13 @@ function createPluginConfig(pluginFile) {
   };
 }
 
-module.exports = () => {
+module.exports = (mode = 'production') => {
   return new Promise(resolve => {
     // find all of the typescript CKEditor plugins and build them
     find.file(/plugin\.ts$/, paths.plugins, function(files) {
       files.forEach(file => {
         console.log(chalk.white.italic('Creating webpack config for building plugin:', file));
-        const config = createPluginConfig(file);
+        const config = createPluginConfig(file, mode);
         pluginConfigs.push(config);
       });
       resolve(pluginConfigs);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "lite",
-  "version": "2.0.0",
-  "description": "Akorda LITE track changes for CKEditor",
+  "name": "@akordacorp/liter",
+  "version": "1.0.0",
+  "description": "Akorda LITEr track changes for CKEditor",
+  "license": "GPL-2.0-only",
   "main": "index.js",
   "files": [
-    "ckeditor/**/*",
+    "plugins/**/*",
     "index.js"
   ],
   "directories": {

--- a/scripts/plugins.js
+++ b/scripts/plugins.js
@@ -61,10 +61,10 @@ function build(config) {
   });
 }
 
-module.exports = () => {
+module.exports = (mode = 'production') => {
   console.log(chalk.cyan('Building Typescript CKEditor Plugins...'));
   return new Promise(resolve => {
-    return createPluginConfigs()
+    return createPluginConfigs(mode)
       .then(configs => {
         return build(configs);
       })

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -60,7 +60,7 @@ if (process.env.HOST) {
 // We require that you explicitly set browsers and do not fall back to
 // browserslist defaults.
 const { checkBrowsers } = require('react-dev-utils/browsersHelper');
-buildCKEditorPlugins()
+buildCKEditorPlugins('development')
   .then(() => {
     return checkBrowsers(paths.appPath, isInteractive);
   })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ const App: React.FC = () => {
     <div className="App">
       <CKEditor
         config={{
-          extraPlugins: 'lite',
+          extraPlugins: 'liter',
         }}
         data="<p>hello world</p>"
         onBeforeLoad={(CKEDITOR: any) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,13 +7,22 @@ const App: React.FC = () => {
     <div className="App">
       <CKEditor
         config={{
+          allowedContent: true,
           extraPlugins: 'liter',
           lite: {
             userId: 191,
             userName: 'Matt Meiske'
           }
         }}
-        data="<p>hello world</p>"
+        data={`<div>
+          <p>hello world</p>
+          <p>
+            one two three
+            <span class="comment-start"></span> testing <span></span>
+            <span class="comment-end"></span>
+            four fix six
+          </p>
+        <div>`}
         onBeforeLoad={(CKEDITOR: any) => {
           CKEDITOR.disableAutoInline = true;
           CKEDITOR.dtd.$removeEmpty.ins = 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,10 @@ const App: React.FC = () => {
       <CKEditor
         config={{
           extraPlugins: 'liter',
+          lite: {
+            userId: 191,
+            name: 'Matt Meiske'
+          }
         }}
         data="<p>hello world</p>"
         onBeforeLoad={(CKEDITOR: any) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ const App: React.FC = () => {
           extraPlugins: 'liter',
           lite: {
             userId: 191,
-            name: 'Matt Meiske'
+            userName: 'Matt Meiske'
           }
         }}
         data="<p>hello world</p>"

--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -2,6 +2,9 @@
 export const AKORDA_CLASS_NAMES = {
   COMMENT_START: 'comment-start',
   COMMENT_END: 'comment-end',
+  COMMENT_MARKER: 'comment-marker',
+  MARKER_IMAGE: 'marker-image',
+  MARKER_COMMENT: 'marker-comment',
   CONCEPT_START: 'lc-start',
   CONCEPT_END: 'lc-end',
   UNSELECTABLE: 'unselectable'
@@ -20,7 +23,7 @@ export const isElementNode = (node: Node): boolean => {
  * @param element
  * @param classNames An array of class names to test against
  */
-export const hasClassFrom = (element: Node, classNames: string[]) => {
+export const hasClassFrom = (element: Node, classNames: string[]): boolean => {
   if (!isElementNode(element) || !classNames) {
     return false;
   }
@@ -31,33 +34,149 @@ export const hasClassFrom = (element: Node, classNames: string[]) => {
  * Returns true if the provided element is a comment marker (start or end)
  * @param element
  */
-export const isAkordaComment = (element: HTMLElement) => {
-  const { COMMENT_START, COMMENT_END } = AKORDA_CLASS_NAMES;
-  return hasClassFrom(element, [COMMENT_START, COMMENT_END]);
+export const isAkordaCommentMarker = (element: HTMLElement): boolean => {
+  const { COMMENT_START, COMMENT_END, COMMENT_MARKER, MARKER_IMAGE } = AKORDA_CLASS_NAMES;
+  return hasClassFrom(element, [COMMENT_MARKER, MARKER_IMAGE, COMMENT_START, COMMENT_END]);
+}
+
+/**
+ * Returns true if the provided element is the start marker for a comment
+ * @param element
+ */
+export const isAkordaCommentStartMarker = (element: HTMLElement): boolean => {
+  return hasClassFrom(element, [AKORDA_CLASS_NAMES.COMMENT_START]);
+}
+
+/**
+ * Returns true if the provided element is the end marker for a comment
+ * @param element
+ */
+export const isAkordaCommentEndMarker = (element: HTMLElement): boolean => {
+  return hasClassFrom(element, [AKORDA_CLASS_NAMES.COMMENT_END]);
+}
+
+/**
+ * Returns true if the element contains commented content
+ * @param element
+ */
+export const isAkordaComment = (node: Node): boolean => {
+  return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_COMMENT]);
+}
+
+// function isImageMarker(element) {
+//   return !!element && !!element.classList && element.classList.contains("marker-image");
+// }
+
+export const isAkordaCommentIcon = (node: Node): boolean => {
+  return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_IMAGE]);
 }
 
 /**
  * Returns true if the provided element is a concept marker (start or end)
  * @param element
  */
-export const isAkordaConcept = (element: HTMLElement) => {
+export const isAkordaConceptMarker = (element: HTMLElement): boolean => {
   const { CONCEPT_START, CONCEPT_END } = AKORDA_CLASS_NAMES;
   return hasClassFrom(element, [CONCEPT_START, CONCEPT_END]);
 }
 
 /**
- * Returns true if the provided element is a marker (start or end) element used to demarcate a range of content
+ * Returns true if the provided element is a marker/boundary (start or end) element used to demarcate a range of content
  * @param element
  */
-export const isAkordaMarkerElement = (element: HTMLElement) => {
-  return isAkordaComment(element) || isAkordaConcept(element);
+export const isAkordaMarkerElement = (element: HTMLElement): boolean => {
+  return isAkordaCommentMarker(element) || isAkordaConceptMarker(element);
 }
 
 /**
  * Returns true if the element (or one of its parents) has a class indicating that it is not selectable/editable.
  * @param element
  */
-export const isAkordaUnselectable = (node: Node) => {
+export const isAkordaUnselectable = (node: Node): boolean => {
   const { UNSELECTABLE } = AKORDA_CLASS_NAMES;
   return !!($(node).closest(`.${UNSELECTABLE}`).length);
+}
+
+/**
+ * Returns true if the first child element of the provided node is a comment
+ * @param element
+ */
+export const isFirstElementAComment = (element: HTMLElement): boolean => {
+  return !!element && !!element.firstElementChild && isAkordaComment(element.firstElementChild);
+}
+
+/**
+ * Copies important comment attribute info from one element to another
+ * @param element
+ * @param newElement
+ */
+export const copyCommentData = (element: HTMLElement, newElement: HTMLElement) => {
+  if (!!element && !!newElement && !!newElement.classList) {
+    newElement.classList.add("marker-comment");
+    newElement.setAttribute("data-c-id", element.getAttribute("data-c-id") || "s" + element.getAttribute("data-w-id"));
+  }
+}
+
+/**
+ * Moves a comment start marker before the provided second element
+ * @param commentStartMarker
+ * @param beforeElement
+ */
+export const insertCommentStartBefore = (commentStartMarker: HTMLElement, beforeElement: HTMLElement): void => {
+  const commentStart = commentStartMarker.cloneNode(true) as HTMLElement;
+  copyCommentData(commentStart, beforeElement);
+  beforeElement.insertAdjacentElement("beforebegin", commentStart);
+  const commentStartParent = commentStartMarker.parentNode;
+  if (commentStartParent) {
+    commentStartParent.removeChild(commentStartMarker);
+  }
+}
+
+/**
+ * Moves a comment end marker (and a comment icon element, if relevant) after the provided second element
+ * @param commentEndMarker
+ * @param afterElement
+ */
+export const insertCommentEndAfter = (commentEndMarker: HTMLElement, afterElement: HTMLElement ): void => {
+  const commentEnd = commentEndMarker.cloneNode(true) as HTMLElement;
+  copyCommentData(commentEnd, afterElement);
+  afterElement.insertAdjacentElement('afterend', commentEnd);
+  const commentEndParent = commentEndMarker.parentNode;
+  if (commentEndParent) {
+    commentEndParent.removeChild(commentEndMarker);
+    const lastChild = commentEndParent.lastElementChild;
+    if (!!lastChild && isAkordaCommentIcon(lastChild)) {
+      const commentIcon = lastChild.cloneNode(true) as HTMLElement;
+      afterElement.insertAdjacentElement('afterend', commentIcon);
+      commentEndParent.removeChild(lastChild);
+    }
+  }
+}
+
+export const isBookmarkStart = (node: Node): boolean => {
+  return isElementNode(node) && (node as HTMLElement).classList.contains('iceBookmark_start');
+}
+
+export const getBookmarkStart = (element: HTMLElement) => {
+  return element.querySelector(".iceBookmark_start");
+}
+
+export const getBookmarkEnd = (element: HTMLElement) => {
+  return element.querySelector(".iceBookmark_end");
+}
+
+export const getCommentStart = (documentElement: HTMLElement, element: HTMLElement) => {
+  const dataCid = element.getAttribute("data-c-id");
+  if (!documentElement || !element || !dataCid) {
+    return null;
+  }
+  return documentElement.querySelector(`.comment-start[data-w-id="${dataCid.slice(1)}"]`);
+}
+
+export const getCommentEnd = (documentElement: HTMLElement, element: HTMLElement) => {
+  const dataCid = element.getAttribute("data-c-id");
+  if (!documentElement || !element || !dataCid) {
+    return null;
+  }
+  return documentElement.querySelector(`.comment-end[data-w-id="${dataCid.slice(1)}"]`);
 }

--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -1,0 +1,17 @@
+
+export const AKORDA_CLASS_NAMES = {
+  COMMENT_START: 'comment-start',
+  COMMENT_END: 'comment-end'
+}
+
+export const hasClassFrom = (element: any, classNames: string[]) => {
+  if (!element || !classNames) {
+    return false;
+  }
+  return !!classNames.find(className => element.classList.contains(className));
+}
+
+export const isAkordaComment = (element: HTMLElement) => {
+  const { COMMENT_START, COMMENT_END } = AKORDA_CLASS_NAMES;
+  return hasClassFrom(element, [COMMENT_START, COMMENT_END]);
+}

--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -1,9 +1,16 @@
 
 export const AKORDA_CLASS_NAMES = {
   COMMENT_START: 'comment-start',
-  COMMENT_END: 'comment-end'
+  COMMENT_END: 'comment-end',
+  CONCEPT_START: 'lc-start',
+  CONCEPT_END: 'lc-end'
 }
 
+/**
+ * Returns true if the provided element has a class from any of the provided class names
+ * @param element
+ * @param classNames An array of class names to test against
+ */
 export const hasClassFrom = (element: any, classNames: string[]) => {
   if (!element || !classNames) {
     return false;
@@ -11,7 +18,28 @@ export const hasClassFrom = (element: any, classNames: string[]) => {
   return !!classNames.find(className => element.classList.contains(className));
 }
 
+/**
+ * Returns true if the provided element is a comment marker (start or end)
+ * @param element
+ */
 export const isAkordaComment = (element: HTMLElement) => {
   const { COMMENT_START, COMMENT_END } = AKORDA_CLASS_NAMES;
   return hasClassFrom(element, [COMMENT_START, COMMENT_END]);
+}
+
+/**
+ * Returns true if the provided element is a concept marker (start or end)
+ * @param element
+ */
+export const isAkordaConcept = (element: HTMLElement) => {
+  const { CONCEPT_START, CONCEPT_END } = AKORDA_CLASS_NAMES;
+  return hasClassFrom(element, [CONCEPT_START, CONCEPT_END]);
+}
+
+/**
+ * Returns true if the provided element is a marker (start or end) element used to demarcate a range of content
+ * @param element
+ */
+export const isAkordaMarkerElement = (element: HTMLElement) => {
+  return isAkordaComment(element) || isAkordaConcept(element);
 }

--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -3,7 +3,16 @@ export const AKORDA_CLASS_NAMES = {
   COMMENT_START: 'comment-start',
   COMMENT_END: 'comment-end',
   CONCEPT_START: 'lc-start',
-  CONCEPT_END: 'lc-end'
+  CONCEPT_END: 'lc-end',
+  UNSELECTABLE: 'unselectable'
+}
+
+/**
+ * Returns true if the provided node is an element
+ * @param node
+ */
+export const isElementNode = (node: Node): boolean => {
+  return !!node && node.nodeType === Node.ELEMENT_NODE;
 }
 
 /**
@@ -11,11 +20,11 @@ export const AKORDA_CLASS_NAMES = {
  * @param element
  * @param classNames An array of class names to test against
  */
-export const hasClassFrom = (element: any, classNames: string[]) => {
-  if (!element || !classNames) {
+export const hasClassFrom = (element: Node, classNames: string[]) => {
+  if (!isElementNode(element) || !classNames) {
     return false;
   }
-  return !!classNames.find(className => element.classList.contains(className));
+  return !!classNames.find(className => (element as HTMLElement).classList.contains(className));
 }
 
 /**
@@ -42,4 +51,13 @@ export const isAkordaConcept = (element: HTMLElement) => {
  */
 export const isAkordaMarkerElement = (element: HTMLElement) => {
   return isAkordaComment(element) || isAkordaConcept(element);
+}
+
+/**
+ * Returns true if the element (or one of its parents) has a class indicating that it is not selectable/editable.
+ * @param element
+ */
+export const isAkordaUnselectable = (node: Node) => {
+  const { UNSELECTABLE } = AKORDA_CLASS_NAMES;
+  return !!($(node).closest(`.${UNSELECTABLE}`).length);
 }

--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -7,7 +7,9 @@ export const AKORDA_CLASS_NAMES = {
   MARKER_COMMENT: 'marker-comment',
   CONCEPT_START: 'lc-start',
   CONCEPT_END: 'lc-end',
-  UNSELECTABLE: 'unselectable'
+  UNSELECTABLE: 'unselectable',
+  ACCEPTED: 'accepted',
+  REMOVED: 'removed'
 }
 
 /**
@@ -63,10 +65,6 @@ export const isAkordaComment = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_COMMENT]);
 }
 
-// function isImageMarker(element) {
-//   return !!element && !!element.classList && element.classList.contains("marker-image");
-// }
-
 export const isAkordaCommentIcon = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_IMAGE]);
 }
@@ -83,9 +81,11 @@ export const isAkordaConceptMarker = (element: HTMLElement): boolean => {
 /**
  * Returns true if the provided element is a marker/boundary (start or end) element used to demarcate a range of content
  * @param element
+ * TODO: Determine if accepted/removed is really a marker/boundary element class name
  */
 export const isAkordaMarkerElement = (element: HTMLElement): boolean => {
-  return isAkordaCommentMarker(element) || isAkordaConceptMarker(element);
+  const { ACCEPTED, REMOVED } = AKORDA_CLASS_NAMES;
+  return isAkordaCommentMarker(element) || isAkordaConceptMarker(element) || hasClassFrom(element, [ACCEPTED, REMOVED]);
 }
 
 /**

--- a/src/plugins/lite/css/lite.css
+++ b/src/plugins/lite/css/lite.css
@@ -27,41 +27,11 @@ ins.ice-no-decoration, del.ice-no-decoration {
 .ICE-Tracking span.ice-ins, .ICE-Tracking ins.ice-ins,
 .ICE-Tracking span.ice-del, .ICE-Tracking del.ice-del {
 	color: #000;
-/*	padding: 1px 0 2px; */
 }
 
 .ICE-Tracking span.ice-del, .ICE-Tracking del.ice-del {
 	display: inline;
 	text-decoration: line-through !important;
 	color: #555;
-	background-color: #e5ffcd !important;
-}
-
-.ICE-Tracking .ice-ins, .ICE-Tracking .ice-ins>*  {
-	background-color: #e5ffcd !important;
-}
-
-.ICE-Tracking .ice-ins.ice-cts-1, .ICE-Tracking .ice-ins.ice-cts-1>*  {
-	background-color: #e5ffcd !important;
-}
-
-.ICE-Tracking .ice-ins.ice-cts-2, .ICE-Tracking .ice-ins.ice-cts-2>*  {
-	background-color: #e3ffff !important;
-}
-
-.ICE-Tracking .ice-ins.ice-cts-3, .ICE-Tracking .ice-ins.ice-cts-3>*  {
-	background-color: #ffdddd !important;
-}
-
-.ICE-Tracking .ice-del.ice-cts-1 {
-	background-color: #e5ffcd !important;
-}
-
-.ICE-Tracking .ice-del.ice-cts-2 {
-	background-color: #e3ffff !important;
-}
-
-.ICE-Tracking .ice-del.ice-cts-3 {
-	background-color: #ffdddd !important;
 }
 

--- a/src/plugins/lite/dom.ts
+++ b/src/plugins/lite/dom.ts
@@ -153,6 +153,12 @@ dom.getElementDimensions = function(element: any) {
   };
 };
 
+dom.remove = function (element: any) {
+  if (element) {
+    return jQuery(element).remove();
+  }
+};
+
 dom.insertBefore = function(before: any, elem: any) {
   $(before).before(elem);
 };

--- a/src/plugins/lite/dom.ts
+++ b/src/plugins/lite/dom.ts
@@ -93,6 +93,8 @@ dom.TEXT_CONTAINER_ELEMENTS = [
   'h6',
   'ins',
   'del',
+  'u',
+  's'
 ];
 
 dom.STUB_ELEMENTS = dom.CONTENT_STUB_ELEMENTS.slice();

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2,7 +2,7 @@ import rangy from 'rangy';
 import dom from './dom';
 import Selection from './selection';
 import Bookmark from './bookmark';
-import { isAkordaMarkerElement } from './akorda';
+import { isAkordaMarkerElement, isAkordaUnselectable } from './akorda';
 
 const ice: any = {};
 
@@ -1491,7 +1491,7 @@ class InlineChangeEditor {
     // elements length may change during the loop so don't optimize
     for (var i = 0; i < elements.length; i++) {
       var elem = elements[i];
-      if (!elem || !elem.parentNode) {
+      if (!elem || !elem.parentNode || isAkordaUnselectable(elem)) {
         // maybe removed as a side effect of removing other stuff
         continue;
       }

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2,6 +2,7 @@ import rangy from 'rangy';
 import dom from './dom';
 import Selection from './selection';
 import Bookmark from './bookmark';
+import { isAkordaComment } from './akorda';
 
 const ice: any = {};
 
@@ -1167,7 +1168,7 @@ class InlineChangeEditor {
    */
 
   _getIceNodeClass(changeType: any) {
-    return this.attrValuePrefix + this.changeTypes[changeType].alias;
+    return `${this.attrValuePrefix}${this.changeTypes[changeType].alias}`;
   }
 
   /**
@@ -1524,7 +1525,7 @@ class InlineChangeEditor {
             this._addDeleteTracking(elem, addDeleteOptions);
             continue;
           }
-          if (dom.hasNoTextOrStubContent(elem)) {
+          if (dom.hasNoTextOrStubContent(elem) && !isAkordaComment(elem)) {
             this._removeNode(elem);
             continue;
           }

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2984,7 +2984,7 @@ class InlineChangeEditor {
       nodes.each(function(i, node) {
         var dataId = node.getAttribute(clsAttr),
           nodeData = saveMap[dataId];
-        if (dataId) {
+        if (dataId && nodeData) {
           delete saveMap[dataId];
           Object.keys(nodeData.attributes).forEach(function(key) {
             node.setAttribute(key, nodeData.attributes[key]);

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2231,8 +2231,8 @@ class InlineChangeEditor {
         var bookmarkEnd: any = getBookmarkEnd(contentAddNode.parentNode);
         var commentStart: any = isParentAComment && getCommentStart(this.element, parent);
         var commentEnd: any = isParentAComment && getCommentEnd(this.element, parent);
-        var repositionCommentsTags: boolean = isParentAComment && !!bookmarkStart && (commentStart.offsetLeft >= bookmarkStart.offsetLeft ||
-          commentEnd.offsetLeft >= bookmarkEnd.offsetLeft
+        var repositionCommentsTags: boolean = isParentAComment && !!bookmarkStart && ((!!commentStart && commentStart.offsetLeft >= bookmarkStart.offsetLeft) ||
+          (!!commentEnd && commentEnd.offsetLeft >= bookmarkEnd.offsetLeft)
         );
 
         this._deleteEmptyNode(contentAddNode);

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -68,17 +68,12 @@ class InlineChangeEditor {
 
   // Prepended to `changeType.alias` for classname uniqueness, if needed
   attrValuePrefix: string = '';
-  // changeTypes: any;
-  // contentEditable: any;
-  // currentUser: any;
   element: any;
   env: any;
   hostMethods: any;
   isPlaceHoldingDeletes: boolean = false;
   $this: any;
   selection: any;
-  // stylePrefix: any;
-  // tooltips: any;
 
   // ice node attribute names:
   attributes: any = {
@@ -88,7 +83,8 @@ class InlineChangeEditor {
     sessionId: 'data-session-id',
     time: 'data-time',
     lastTime: 'data-last-change-time',
-    changeData: 'data-changedata', // arbitrary data to associate with the node, e.g. version
+    changeData: 'data-changedata', // arbitrary data to associate with the node, e.g. version,
+    changeOwnId: "data-id" // TODO: re-evaluate this akorda attribute
   };
 
   classes: any = {
@@ -1247,6 +1243,9 @@ class InlineChangeEditor {
 
     if (!ctNode.getAttribute(this.attributes.changeId)) {
       attributes[this.attributes.changeId] = changeid;
+      if (!ctNode.getAttribute(this.attributes.changeOwnId)) {
+        attributes[this.attributes.changeOwnId] = `0${changeid}`;
+      }
     }
     // handle missing userid, try to set username according to userid
     var userId = ctNode.getAttribute(this.attributes.userId);
@@ -2771,6 +2770,11 @@ class InlineChangeEditor {
         changeid = this.getNewChangeId();
         // @ts-ignore
         el.setAttribute(this.attributes.changeId, changeid);
+        // @ts-ignore
+        if (!el.getAttribute(this.attributes.changeOwnId)) {
+          // @ts-ignore
+          el.setAttribute(this.attributes.changeOwnId, `0${changeid}`);
+        }
       }
       // @ts-ignore
       var timeStamp = parseInt(el.getAttribute(this.attributes.time) || '');

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2,7 +2,7 @@ import rangy from 'rangy';
 import dom from './dom';
 import Selection from './selection';
 import Bookmark from './bookmark';
-import { isAkordaComment } from './akorda';
+import { isAkordaMarkerElement } from './akorda';
 
 const ice: any = {};
 
@@ -1524,7 +1524,7 @@ class InlineChangeEditor {
             this._addDeleteTracking(elem, addDeleteOptions);
             continue;
           }
-          if (dom.hasNoTextOrStubContent(elem) && !isAkordaComment(elem)) {
+          if (dom.hasNoTextOrStubContent(elem) && !isAkordaMarkerElement(elem)) {
             this._removeNode(elem);
             continue;
           }

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -485,7 +485,8 @@ class InlineChangeEditor {
       } else {
         this._cleanupSelection(range, false, true);
         // if we're inside a current insert range, let the editor take care of the deletion
-        if (this._isCurrentUserIceNode(this._getIceNode(range.startContainer, INSERT_TYPE))) {
+        // ignore if we are performing forward delete
+        if (!right && this._isCurrentUserIceNode(this._getIceNode(range.startContainer, INSERT_TYPE))) {
           return false;
         }
 
@@ -2366,10 +2367,9 @@ class InlineChangeEditor {
    * Returns true if the keypress event provided is either the backspace or delete keys,
    * or a combination of CTL + DEL
    */
-  _isDeleteKey(e: any) {
-    var key = e.keyCode ? e.keyCode : e.which;
+  _isDeleteKey(key: number, ctrlKey: boolean) {
     const isPrincipalDelete = [dom.DOM_VK_DELETE, 46].includes(key);
-    const isSecondaryDelete = e.ctrlKey && key === 68; // CTL + D
+    const isSecondaryDelete = ctrlKey && key === 68; // CTL + D
     return isPrincipalDelete || isSecondaryDelete;
   }
 
@@ -2377,10 +2377,10 @@ class InlineChangeEditor {
    * Returns true if the event should be cancelled
    */
   keyPress(e: any) {
-    var key = e.keyCode ? e.keyCode : e.which;
+    const key = e.keyCode ? e.keyCode : e.which;
     var c = null;
 
-    if (this._isDeleteKey(e)) {
+    if (this._isDeleteKey(key, e.ctrlKey)) {
       return this._handleDeleteKey(key);
     }
 

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -77,14 +77,13 @@ class InlineChangeEditor {
 
   // ice node attribute names:
   attributes: any = {
-    changeId: 'data-cid',
+    changeId: 'data-id',
     userId: 'data-userid',
     userName: 'data-username',
     sessionId: 'data-session-id',
     time: 'data-time',
     lastTime: 'data-last-change-time',
     changeData: 'data-changedata', // arbitrary data to associate with the node, e.g. version,
-    changeOwnId: "data-id" // TODO: re-evaluate this akorda attribute
   };
 
   classes: any = {
@@ -171,6 +170,7 @@ class InlineChangeEditor {
         if (!isNaN(st)) {
           this._userStyles[id] = this.stylePrefix + '-' + st;
           this._uniqueStyleIndex = Math.max(st, this._uniqueStyleIndex);
+          this._uniqueIDIndex = Math.max(st, this._uniqueIDIndex);
           this._styles[st] = true;
         }
       }
@@ -1244,9 +1244,6 @@ class InlineChangeEditor {
 
     if (!ctNode.getAttribute(this.attributes.changeId)) {
       attributes[this.attributes.changeId] = changeid;
-      if (!ctNode.getAttribute(this.attributes.changeOwnId)) {
-        attributes[this.attributes.changeOwnId] = `0${changeid}`;
-      }
     }
     // handle missing userid, try to set username according to userid
     var userId = ctNode.getAttribute(this.attributes.userId);
@@ -2734,6 +2731,7 @@ class InlineChangeEditor {
   _loadFromDom() {
     this._changes = {};
     this._uniqueStyleIndex = 0;
+    this._uniqueIDIndex = 1;
     var myUserId = this.currentUser && this.currentUser.id,
       myUserName = (this.currentUser && this.currentUser.name) || '',
       now = new Date().getTime(),
@@ -2785,11 +2783,6 @@ class InlineChangeEditor {
         changeid = this.getNewChangeId();
         // @ts-ignore
         el.setAttribute(this.attributes.changeId, changeid);
-        // @ts-ignore
-        if (!el.getAttribute(this.attributes.changeOwnId)) {
-          // @ts-ignore
-          el.setAttribute(this.attributes.changeOwnId, `0${changeid}`);
-        }
       }
       // @ts-ignore
       var timeStamp = parseInt(el.getAttribute(this.attributes.time) || '');

--- a/src/plugins/lite/lang/de.js
+++ b/src/plugins/lite/lang/de.js
@@ -1,4 +1,4 @@
-﻿CKEDITOR.plugins.setLang( 'lite', 'de', {
+﻿CKEDITOR.plugins.setLang( 'liter', 'de', {
 	TOGGLE_TRACKING: "Überarbeitungsmodus umschalten",
 	TOGGLE_SHOW: "Überarbeitungsmodus umschalten",
 	ACCEPT_ALL: "Alle Änderungen annehmen",

--- a/src/plugins/lite/lang/en.js
+++ b/src/plugins/lite/lang/en.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'lite', 'en', {
+CKEDITOR.plugins.setLang( 'liter', 'en', {
 	TOGGLE_TRACKING: "Toggle Tracking Changes",
 	TOGGLE_SHOW: "Toggle Tracking Changes",
 	ACCEPT_ALL: "Accept all changes",

--- a/src/plugins/lite/lang/fr.js
+++ b/src/plugins/lite/lang/fr.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'lite', 'fr', {
+CKEDITOR.plugins.setLang( 'liter', 'fr', {
 	TOGGLE_TRACKING: "Activer/désactiver le suivi des modifications",
 	TOGGLE_SHOW: "Activer/désactiver le suivi des modifications",
 	ACCEPT_ALL: "Accepter toutes les modifications",

--- a/src/plugins/lite/lang/pt-br.js
+++ b/src/plugins/lite/lang/pt-br.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang('lite', 'pt-br', {
+CKEDITOR.plugins.setLang('liter', 'pt-br', {
 	TOGGLE_TRACKING: "Alternar marcas de revisão",
 	TOGGLE_SHOW: "Alternar marcas de revisão",
 	ACCEPT_ALL: "Aceitar todas as modificações",

--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -113,14 +113,13 @@ const LITE = {
     deleteClass: 'ice-del',
     insertClass: 'ice-ins',
     attributes: {
-      changeId: 'data-cid',
+      changeId: 'data-id',
       userId: 'data-userid',
       userName: 'data-username',
       sessionId: 'data-session-id',
       changeData: 'data-changedata',
       time: 'data-time',
       lastTime: 'data-last-change-time',
-      changeOwnId: "data-id"
     },
     stylePrefix: 'ice-cts',
     preserveOnPaste: 'p',

--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -439,7 +439,7 @@ function elementMatchesSelectors($el: any, patterns: any) {
  * the lifecycle of {@link LITE.LITEPlugin} the real plugin object.
  *
  */
-CKEDITOR.plugins.add('lite', {
+CKEDITOR.plugins.add('liter', {
   lang: ['en', 'de', 'fr', 'pt-br'],
   _scriptsLoaded: null, // not false, which means we're loading
 
@@ -574,7 +574,7 @@ LITEPlugin.prototype = {
    * @param {LITE.configuration} config a LITE configuration object, not null, ready to be used as a local copy
    */
   init: function(ed: any, config: any) {
-    var lang = ed.lang.lite;
+    var lang = ed.lang.liter;
     this._editor = ed;
     this._domLoaded = false;
     this._editor = null;

--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -120,6 +120,7 @@ const LITE = {
       changeData: 'data-changedata',
       time: 'data-time',
       lastTime: 'data-last-change-time',
+      changeOwnId: "data-id"
     },
     stylePrefix: 'ice-cts',
     preserveOnPaste: 'p',

--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -1,4 +1,6 @@
 import ice from './ice';
+import dom from './dom';
+
 /*
 Copyright 2015 LoopIndex, This file is part of the Track Changes plugin for CKEditor.
 
@@ -146,7 +148,7 @@ function isLITENode(node: HTMLElement) {
 
 function cleanNode(node: any) {
   var ret, i, child;
-  if (node.nodeType === ice.dom.ELEMENT_NODE) {
+  if (node.nodeType === dom.ELEMENT_NODE) {
     var children = node.childNodes;
     for (i = 0; i < children.length; ++i) {
       child = children[i];
@@ -1826,6 +1828,7 @@ LITEPlugin.prototype = {
       time: any = new Date(change.time),
       lastTime: any = new Date(change.lastTime),
       lang: any = this._editor.lang.liter;
+
     title = title.replace(
       /%a/g,
       'insert' === change.type ? lang.CHANGE_TYPE_ADDED : lang.CHANGE_TYPE_DELETED

--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -757,7 +757,7 @@ LITEPlugin.prototype = {
 
     var tracking = undefined === track ? !this._isTracking : track,
       e = this._editor,
-      lang = this._editor.lang.lite,
+      lang = this._editor.lang.liter,
       force = options && options.force;
     if (!tracking && this._isTracking && !force) {
       var nChanges = this._tracker.countChanges({ verify: true });
@@ -795,7 +795,7 @@ LITEPlugin.prototype = {
 
   toggleShow: function(show: any, bNotify: any) {
     var vis = typeof show === 'undefined' ? !this._isVisible : show,
-      lang = this._editor.lang.lite;
+      lang = this._editor.lang.liter;
     this._isVisible = vis;
     if (this._isTracking) {
       this._setCommandsState(
@@ -1825,7 +1825,7 @@ LITEPlugin.prototype = {
     var title = this._config.tooltipTemplate || defaultTooltipTemplate,
       time: any = new Date(change.time),
       lastTime: any = new Date(change.lastTime),
-      lang: any = this._editor.lang.lite;
+      lang: any = this._editor.lang.liter;
     title = title.replace(
       /%a/g,
       'insert' === change.type ? lang.CHANGE_TYPE_ADDED : lang.CHANGE_TYPE_DELETED


### PR DESCRIPTION
## What changed
* For now, change the name of the plugin to `liter` rather than `lite` to that both the original plugin and the new plugin can be tested without any name collisions
* Ensure that when in development mode (using the React app for testing) that we do not minimize the resulting plugin js.
* Also adjust the ignore prop on the copy of the plugin assets to the build folder so that it ignores the typescript files on a production build.
* Add custom Akorda code and various fixes