### PR TITLE
fix: Tooltip and package adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@akordacorp/liter",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Akorda LITEr track changes for CKEditor",
   "license": "GPL-2.0-only",
   "main": "index.js",
   "files": [
-    "plugins/**/*",
+    "liter/**/*",
     "index.js"
   ],
   "directories": {

--- a/src/plugins/lite/css/opentip.css
+++ b/src/plugins/lite/css/opentip.css
@@ -6,7 +6,7 @@
 }
 .opentip-container {
   position: absolute;
-  max-width: 300px;
+  max-width: 200px;
   z-index: 100;
   -webkit-transition: -webkit-transform 1s ease-in-out;
   -moz-transition: -moz-transform 1s ease-in-out;
@@ -151,7 +151,7 @@
 .opentip-container.style-glass .opentip {
   padding: 15px 25px;
   color: #317cc5;
-  background-color: rgba(255,255,255,0.75);
+  background-color: rgba(246,248,250,0.75);
 }
 .opentip-container.ot-hide-effect-fade {
   -webkit-transition: -webkit-transform 0.5s ease-in-out, opacity 1s ease-in-out;

--- a/src/plugins/lite/js/opentip-adapter.js
+++ b/src/plugins/lite/js/opentip-adapter.js
@@ -1830,7 +1830,11 @@
 
 		showTooltip: function (node, title, boundingElement) {
 			var options = jQuery.extend({
-					target: node,
+          target: node,
+          targetJoint: 'bottom right',
+          tipJoint: 'left',
+          borderRadius: 3,
+          borderColor: '#317cc5',
 					boundingElement: boundingElement
 				}, ttOptions),
 				tip = new Opentip(node, title, options);


### PR DESCRIPTION
* Updated the files references in `package.json` to ensure the proper files are included in the published package.
* Modified the css/js for the tooltip so that it displays in a light gray background with a blue border.