### PR TITLE
fix: Add "section" to list of known text container elements

### DIFF
--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -1,4 +1,3 @@
-
 export const AKORDA_CLASS_NAMES = {
   COMMENT_START: 'comment-start',
   COMMENT_END: 'comment-end',
@@ -9,8 +8,8 @@ export const AKORDA_CLASS_NAMES = {
   CONCEPT_END: 'lc-end',
   UNSELECTABLE: 'unselectable',
   ACCEPTED: 'accepted',
-  REMOVED: 'removed'
-}
+  REMOVED: 'removed',
+};
 
 /**
  * Returns true if the provided node is an element
@@ -18,7 +17,7 @@ export const AKORDA_CLASS_NAMES = {
  */
 export const isElementNode = (node: Node): boolean => {
   return !!node && node.nodeType === Node.ELEMENT_NODE;
-}
+};
 
 /**
  * Returns true if the provided element has a class from any of the provided class names
@@ -30,7 +29,7 @@ export const hasClassFrom = (element: Node, classNames: string[]): boolean => {
     return false;
   }
   return !!classNames.find(className => (element as HTMLElement).classList.contains(className));
-}
+};
 
 /**
  * Returns true if the provided element is a comment marker (start or end)
@@ -39,7 +38,7 @@ export const hasClassFrom = (element: Node, classNames: string[]): boolean => {
 export const isAkordaCommentMarker = (element: HTMLElement): boolean => {
   const { COMMENT_START, COMMENT_END, COMMENT_MARKER, MARKER_IMAGE } = AKORDA_CLASS_NAMES;
   return hasClassFrom(element, [COMMENT_MARKER, MARKER_IMAGE, COMMENT_START, COMMENT_END]);
-}
+};
 
 /**
  * Returns true if the provided element is the start marker for a comment
@@ -47,7 +46,7 @@ export const isAkordaCommentMarker = (element: HTMLElement): boolean => {
  */
 export const isAkordaCommentStartMarker = (element: HTMLElement): boolean => {
   return hasClassFrom(element, [AKORDA_CLASS_NAMES.COMMENT_START]);
-}
+};
 
 /**
  * Returns true if the provided element is the end marker for a comment
@@ -55,7 +54,7 @@ export const isAkordaCommentStartMarker = (element: HTMLElement): boolean => {
  */
 export const isAkordaCommentEndMarker = (element: HTMLElement): boolean => {
   return hasClassFrom(element, [AKORDA_CLASS_NAMES.COMMENT_END]);
-}
+};
 
 /**
  * Returns true if the element contains commented content
@@ -63,11 +62,11 @@ export const isAkordaCommentEndMarker = (element: HTMLElement): boolean => {
  */
 export const isAkordaComment = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_COMMENT]);
-}
+};
 
 export const isAkordaCommentIcon = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_IMAGE]);
-}
+};
 
 /**
  * Returns true if the provided element is a concept marker (start or end)
@@ -76,7 +75,7 @@ export const isAkordaCommentIcon = (node: Node): boolean => {
 export const isAkordaConceptMarker = (element: HTMLElement): boolean => {
   const { CONCEPT_START, CONCEPT_END } = AKORDA_CLASS_NAMES;
   return hasClassFrom(element, [CONCEPT_START, CONCEPT_END]);
-}
+};
 
 /**
  * Returns true if the provided element is a marker/boundary (start or end) element used to demarcate a range of content
@@ -85,8 +84,12 @@ export const isAkordaConceptMarker = (element: HTMLElement): boolean => {
  */
 export const isAkordaMarkerElement = (element: HTMLElement): boolean => {
   const { ACCEPTED, REMOVED } = AKORDA_CLASS_NAMES;
-  return isAkordaCommentMarker(element) || isAkordaConceptMarker(element) || hasClassFrom(element, [ACCEPTED, REMOVED]);
-}
+  return (
+    isAkordaCommentMarker(element) ||
+    isAkordaConceptMarker(element) ||
+    hasClassFrom(element, [ACCEPTED, REMOVED])
+  );
+};
 
 /**
  * Returns true if the element (or one of its parents) has a class indicating that it is not selectable/editable.
@@ -94,8 +97,8 @@ export const isAkordaMarkerElement = (element: HTMLElement): boolean => {
  */
 export const isAkordaUnselectable = (node: Node): boolean => {
   const { UNSELECTABLE } = AKORDA_CLASS_NAMES;
-  return !!($(node).closest(`.${UNSELECTABLE}`).length);
-}
+  return !!$(node).closest(`.${UNSELECTABLE}`).length;
+};
 
 /**
  * Returns true if the first child element of the provided node is a comment
@@ -103,7 +106,7 @@ export const isAkordaUnselectable = (node: Node): boolean => {
  */
 export const isFirstElementAComment = (element: HTMLElement): boolean => {
   return !!element && !!element.firstElementChild && isAkordaComment(element.firstElementChild);
-}
+};
 
 /**
  * Copies important comment attribute info from one element to another
@@ -112,32 +115,41 @@ export const isFirstElementAComment = (element: HTMLElement): boolean => {
  */
 export const copyCommentData = (element: HTMLElement, newElement: HTMLElement) => {
   if (!!element && !!newElement && !!newElement.classList) {
-    newElement.classList.add("marker-comment");
-    newElement.setAttribute("data-c-id", element.getAttribute("data-c-id") || "s" + element.getAttribute("data-w-id"));
+    newElement.classList.add('marker-comment');
+    newElement.setAttribute(
+      'data-c-id',
+      element.getAttribute('data-c-id') || 's' + element.getAttribute('data-w-id')
+    );
   }
-}
+};
 
 /**
  * Moves a comment start marker before the provided second element
  * @param commentStartMarker
  * @param beforeElement
  */
-export const insertCommentStartBefore = (commentStartMarker: HTMLElement, beforeElement: HTMLElement): void => {
+export const insertCommentStartBefore = (
+  commentStartMarker: HTMLElement,
+  beforeElement: HTMLElement
+): void => {
   const commentStart = commentStartMarker.cloneNode(true) as HTMLElement;
   copyCommentData(commentStart, beforeElement);
-  beforeElement.insertAdjacentElement("beforebegin", commentStart);
+  beforeElement.insertAdjacentElement('beforebegin', commentStart);
   const commentStartParent = commentStartMarker.parentNode;
   if (commentStartParent) {
     commentStartParent.removeChild(commentStartMarker);
   }
-}
+};
 
 /**
  * Moves a comment end marker (and a comment icon element, if relevant) after the provided second element
  * @param commentEndMarker
  * @param afterElement
  */
-export const insertCommentEndAfter = (commentEndMarker: HTMLElement, afterElement: HTMLElement ): void => {
+export const insertCommentEndAfter = (
+  commentEndMarker: HTMLElement,
+  afterElement: HTMLElement
+): void => {
   const commentEnd = commentEndMarker.cloneNode(true) as HTMLElement;
   copyCommentData(commentEnd, afterElement);
   afterElement.insertAdjacentElement('afterend', commentEnd);
@@ -151,35 +163,35 @@ export const insertCommentEndAfter = (commentEndMarker: HTMLElement, afterElemen
       commentEndParent.removeChild(lastChild);
     }
   }
-}
+};
 
 export const isBookmarkStart = (node: Node): boolean => {
   return isElementNode(node) && (node as HTMLElement).classList.contains('iceBookmark_start');
-}
+};
 
 export const getBookmarkStart = (element: HTMLElement) => {
-  return element.querySelector(".iceBookmark_start");
-}
+  return element.querySelector('.iceBookmark_start');
+};
 
 export const getBookmarkEnd = (element: HTMLElement) => {
-  return element.querySelector(".iceBookmark_end");
-}
+  return element.querySelector('.iceBookmark_end');
+};
 
 export const getCommentStart = (documentElement: HTMLElement, element: HTMLElement) => {
-  const dataCid = element.getAttribute("data-c-id");
+  const dataCid = element.getAttribute('data-c-id');
   if (!documentElement || !element || !dataCid) {
     return null;
   }
   return documentElement.querySelector(`.comment-start[data-w-id="${dataCid.slice(1)}"]`);
-}
+};
 
 export const getCommentEnd = (documentElement: HTMLElement, element: HTMLElement) => {
-  const dataCid = element.getAttribute("data-c-id");
+  const dataCid = element.getAttribute('data-c-id');
   if (!documentElement || !element || !dataCid) {
     return null;
   }
   return documentElement.querySelector(`.comment-end[data-w-id="${dataCid.slice(1)}"]`);
-}
+};
 
 /**
  * We currently can encounter two different types of timestamps in a document (seconds and milliseconds) for tracked changes.
@@ -192,4 +204,4 @@ export const ensureMillsecondsTimestamp = (timestamp: number): number => {
   const MILLISECOND_TIMESTAMP_DIGIT_COUNT = 13;
   const timestampDigitCount = timestamp.toString().length;
   return timestampDigitCount >= MILLISECOND_TIMESTAMP_DIGIT_COUNT ? timestamp : timestamp * 1000;
-}
+};

--- a/src/plugins/lite/dom.ts
+++ b/src/plugins/lite/dom.ts
@@ -94,7 +94,8 @@ dom.TEXT_CONTAINER_ELEMENTS = [
   'ins',
   'del',
   'u',
-  's'
+  's',
+  'section'
 ];
 
 dom.STUB_ELEMENTS = dom.CONTENT_STUB_ELEMENTS.slice();

--- a/src/plugins/lite/dom.ts
+++ b/src/plugins/lite/dom.ts
@@ -95,7 +95,7 @@ dom.TEXT_CONTAINER_ELEMENTS = [
   'del',
   'u',
   's',
-  'section'
+  'section',
 ];
 
 dom.STUB_ELEMENTS = dom.CONTENT_STUB_ELEMENTS.slice();
@@ -156,7 +156,7 @@ dom.getElementDimensions = function(element: any) {
   };
 };
 
-dom.remove = function (element: any) {
+dom.remove = function(element: any) {
   if (element) {
     return jQuery(element).remove();
   }

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2,7 +2,23 @@ import rangy from 'rangy';
 import dom from './dom';
 import Selection from './selection';
 import Bookmark from './bookmark';
-import { isAkordaMarkerElement, isAkordaUnselectable, isAkordaComment, isFirstElementAComment, copyCommentData, isAkordaCommentStartMarker, isAkordaCommentEndMarker, insertCommentStartBefore, insertCommentEndAfter, isBookmarkStart, getBookmarkStart, getBookmarkEnd, getCommentStart, getCommentEnd, ensureMillsecondsTimestamp } from './akorda';
+import {
+  isAkordaMarkerElement,
+  isAkordaUnselectable,
+  isAkordaComment,
+  isFirstElementAComment,
+  copyCommentData,
+  isAkordaCommentStartMarker,
+  isAkordaCommentEndMarker,
+  insertCommentStartBefore,
+  insertCommentEndAfter,
+  isBookmarkStart,
+  getBookmarkStart,
+  getBookmarkEnd,
+  getCommentStart,
+  getCommentEnd,
+  ensureMillsecondsTimestamp,
+} from './akorda';
 
 const ice: any = {};
 
@@ -486,7 +502,10 @@ class InlineChangeEditor {
         this._cleanupSelection(range, false, true);
         // if we're inside a current insert range, let the editor take care of the deletion
         // ignore if we are performing forward delete
-        if (!right && this._isCurrentUserIceNode(this._getIceNode(range.startContainer, INSERT_TYPE))) {
+        if (
+          !right &&
+          this._isCurrentUserIceNode(this._getIceNode(range.startContainer, INSERT_TYPE))
+        ) {
           return false;
         }
 
@@ -2192,11 +2211,15 @@ class InlineChangeEditor {
         // Check if it is a comment marker element
         const isParentAComment = isAkordaComment(parent);
         // Check if it is deleting the first character from the comment
-        const isDeletingCommentBeginning = (cInd === 0 && isParentAComment);
+        const isDeletingCommentBeginning = cInd === 0 && isParentAComment;
         // Check if it is deleting the last character from the comment
-        const isDeletingCommentEnding = (cInd >= nChildren - 1 && isParentAComment);
+        const isDeletingCommentEnding = cInd >= nChildren - 1 && isParentAComment;
 
-        if ((cInd > 0 && cInd >= nChildren - 1) || isDeletingCommentBeginning || isDeletingCommentEnding) {
+        if (
+          (cInd > 0 && cInd >= nChildren - 1) ||
+          isDeletingCommentBeginning ||
+          isDeletingCommentEnding
+        ) {
           if (!isDeletingCommentBeginning && !isDeletingCommentEnding) {
             // Default behavior
             dom.insertAfter(contentAddNode, ctNode);
@@ -2231,9 +2254,11 @@ class InlineChangeEditor {
         var bookmarkEnd: any = getBookmarkEnd(contentAddNode.parentNode);
         var commentStart: any = isParentAComment && getCommentStart(this.element, parent);
         var commentEnd: any = isParentAComment && getCommentEnd(this.element, parent);
-        var repositionCommentsTags: boolean = isParentAComment && !!bookmarkStart && ((!!commentStart && commentStart.offsetLeft >= bookmarkStart.offsetLeft) ||
-          (!!commentEnd && commentEnd.offsetLeft >= bookmarkEnd.offsetLeft)
-        );
+        var repositionCommentsTags: boolean =
+          isParentAComment &&
+          !!bookmarkStart &&
+          ((!!commentStart && commentStart.offsetLeft >= bookmarkStart.offsetLeft) ||
+            (!!commentEnd && commentEnd.offsetLeft >= bookmarkEnd.offsetLeft));
 
         this._deleteEmptyNode(contentAddNode);
         if (range && moveLeft) {
@@ -2242,22 +2267,31 @@ class InlineChangeEditor {
           this.selection.addRange(range);
         }
         if (repositionCommentsTags) {
-          if (isParentAComment && (
-              isAkordaComment(ctNode.nextElementSibling) || isFirstElementAComment(ctNode.nextElementSibling)
-              )
-            ) {
+          if (
+            isParentAComment &&
+            (isAkordaComment(ctNode.nextElementSibling) ||
+              isFirstElementAComment(ctNode.nextElementSibling))
+          ) {
             copyCommentData(parent, ctNode);
           }
           var nextElementSibling = ctNode.nextElementSibling;
           if (!!nextElementSibling && isAkordaCommentStartMarker(nextElementSibling.children[1])) {
             insertCommentStartBefore(nextElementSibling.children[1], ctNode);
-          } else if (!!nextElementSibling && isAkordaCommentStartMarker(nextElementSibling.children[0])) {
+          } else if (
+            !!nextElementSibling &&
+            isAkordaCommentStartMarker(nextElementSibling.children[0])
+          ) {
             insertCommentStartBefore(nextElementSibling.children[0], ctNode);
           } else {
             let previousSibling = ctNode.previousElementSibling;
-            if (!!previousSibling && !!previousSibling.firstChild && isAkordaCommentStartMarker(previousSibling.firstChild) &&
-              (isBookmarkStart(previousSibling.firstChild.nextElementSibling) || (isBookmarkStart(previousSibling.firstChild.nextElementSibling.firstChild)))) {
-                insertCommentStartBefore(previousSibling.firstChild, ctNode);
+            if (
+              !!previousSibling &&
+              !!previousSibling.firstChild &&
+              isAkordaCommentStartMarker(previousSibling.firstChild) &&
+              (isBookmarkStart(previousSibling.firstChild.nextElementSibling) ||
+                isBookmarkStart(previousSibling.firstChild.nextElementSibling.firstChild))
+            ) {
+              insertCommentStartBefore(previousSibling.firstChild, ctNode);
             }
           }
           var previousSibling = ctNode.previousElementSibling;

--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -344,11 +344,11 @@ function elementMatchesSelectors($el: any, patterns: any) {
  * the path (relative to the LITE plugin.js file) to jQuery
  */
 
- /**
-  * @member LITE.configuration
-  * @property {Function} tooltipDisplay
-  * A function that is given the change object and which returns a string to be displayed in the toolitp
-  */
+/**
+ * @member LITE.configuration
+ * @property {Function} tooltipDisplay
+ * A function that is given the change object and which returns a string to be displayed in the toolitp
+ */
 
 /**
  * @member LITE.configuration
@@ -426,14 +426,12 @@ CKEDITOR.plugins.add('liter', {
 
     this._scriptsLoaded = false;
     var jQueryLoaded = typeof jQuery === 'function',
-    self = this,
-    jQueryPath = liteConfig.jQueryPath || 'js/jquery.min.js',
-    scripts: any[] = [];
+      self = this,
+      jQueryPath = liteConfig.jQueryPath || 'js/jquery.min.js',
+      scripts: any[] = [];
 
     if (!global[ttConfig.classPath]) {
-      var sources = [
-        'opentip-adapter.js',
-      ];
+      var sources = ['opentip-adapter.js'];
       for (var i = 0, len = sources.length; i < len; ++i) {
         scripts.push(path + 'js/' + sources[i]);
       }


### PR DESCRIPTION
* If you have `allowedContent` = true in the editor config and `section` elements in the editor content, a deletion and then an insert will cause the cursor to be moved to the parent of the section element rather than remaining in the section. This is because the `section` element is not in the list of known text container elements. Adding section to that list.
* Prettier was not formatting the content. Manually formatted files until commit hook can be investigated.