### PR TITLE
fix: tooltip not hidden before snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akordacorp/liter",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Akorda LITEr track changes for CKEditor",
   "license": "GPL-2.0-only",
   "main": "index.js",

--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -1043,7 +1043,7 @@ LITEPlugin.prototype = {
         e.on('paste', paste, null, null, 1);
       }
       e.on('beforeGetData', this._onBeforeGetData.bind(this));
-      e.on('beoreUndoImage', this._onBeforeGetData.bind(this)); // treat before undo as before getdata
+      e.on('beforeUndoImage', this._onBeforeGetData.bind(this)); // treat before undo as before getdata
       e.on('insertHtml', paste, null, null, 1);
       e.on('insertText', paste, null, null, 1);
       e.on('insertElement', paste, null, null, 1);


### PR DESCRIPTION
## Issue before fix
* Undo was not working correctly at times when you hover+click+delete because a snapshot image was saved that included the tooltip addition from the hover action.

## What changed
* Discovered the bug was due to a typo in the setup of the original event listener: `beoreUndoImage` instead of `beforeUndoImage`.