### PR TITLE
fix: allow delete-left for block content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akordacorp/liter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Akorda LITEr track changes for CKEditor",
   "license": "GPL-2.0-only",
   "main": "index.js",

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -1906,6 +1906,12 @@ class InlineChangeEditor {
           range.collapse();
           return true;
         }
+
+        // let the browser merge the text (and delete the block element) when the caret is at the start of a block
+        // and the user deletes left.
+        if (prevContainer.nextSibling === parentBlock) {
+          return false;
+        }
       }
     }
 


### PR DESCRIPTION
## Issue before fix
* If you are in a block element (e.g., p) and hit return by accident, you cannot hit backspace and return the text back to its original location. You are stuck and cannot delete the new block that was created. Instead, the cursor bounces to the previous content node (the first paragraph) and leaves the accidental paragraph in place. This is frustrating.
* We want to treat paragraphs/block elements like list items. If the caret is at the beginning of a list item, the left delete (backspace) will delete the list item and move the content up into the previous list item (or editable content element).

## What changed
* Added a check in left-delete so that if the caret is at the beginning of a block, the delete will then be the default browser delete without retaining the structure/block. This will only happen if the range is collapsed. Otherwise if you select multiple paragraphs and delete, the structure is retained.