### PR TITLE
fix: allow delete for block content (part 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akordacorp/liter",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Akorda LITEr track changes for CKEditor",
   "license": "GPL-2.0-only",
   "main": "index.js",

--- a/src/plugins/lite/dom.ts
+++ b/src/plugins/lite/dom.ts
@@ -480,6 +480,10 @@ dom.getCommonAncestor = function(a: any, b: any) {
   return null;
 };
 
+dom.contains = function(container: any, element: any) {
+  return $.contains(container, element);
+};
+
 dom.getNextNode = function(node: any, container: any) {
   if (node) {
     while (node.parentNode) {

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -1908,8 +1908,12 @@ class InlineChangeEditor {
         }
 
         // let the browser merge the text (and delete the block element) when the caret is at the start of a block
-        // and the user deletes left.
-        if (prevContainer.nextSibling === parentBlock) {
+        // and the user deletes left. We check that the previous container is in a sibling branch of the caret's block
+        // branch, which indicates that we can delete all blocks in between.
+        if (
+          prevContainer.nextSibling === parentBlock ||
+          dom.contains(prevContainer.nextSibling, parentBlock)
+        ) {
           return false;
         }
       }


### PR DESCRIPTION
## Issue before fix
* The previous fix works fine if there are no intermediate block elements between the caret and the new previous container to which the caret will move. But if the text is in a paragraph in a div (for example), the div would not get deleted.

```html
<div>
   <p>one</p>
</div>
<div>
   <p>^two</p>
</div>
```

## What changed
* Added a check that the previous container's next sibling is an ancestor of the caret's parent block, which allows us to delete all block ancestors up to the new container node branch.