### PR TITLE
feat: expose create-ice-node method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akordacorp/liter",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Akorda LITEr track changes for CKEditor",
   "license": "GPL-2.0-only",
   "main": "index.js",

--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -815,6 +815,15 @@ LITEPlugin.prototype = {
   },
 
   /**
+   * Creates an (ice) tracked changes element (either insert or delete)
+   */
+  createTrackedChangeElement: function(isInsert: boolean, childNode?: any, changeId?: any) {
+    const changeType = isInsert ? 'insertType' : 'deleteType';
+    const iceNode = this._tracker && this._tracker._createIceNode(changeType, childNode, changeId);
+    return new CKEDITOR.dom.element(iceNode);
+  },
+
+  /**
    * Enable or disable the accept changes ui. This does not affect the availabibility of the accept/reject api
    * @param {Boolean} bEnable
    */


### PR DESCRIPTION
## Issue before fix
* The ice method for creating a tracked-change element is valuable for other plugins.

## What changed
* exposed the `_createIceNode` method from `ice` via the plugin interface.