### PR TITLE
fix: allow delete nested element inside of an insert element

### DIFF
--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -64,10 +64,6 @@ export const isAkordaComment = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_COMMENT]);
 };
 
-export const isNodeElement = (node: Node): boolean => {
-  return node.nodeType === Node.ELEMENT_NODE;
-};
-
 export const isAkordaCommentIcon = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_IMAGE]);
 };

--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -64,6 +64,10 @@ export const isAkordaComment = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_COMMENT]);
 };
 
+export const isNodeElement = (node: Node): boolean => {
+  return node.nodeType === Node.ELEMENT_NODE;
+};
+
 export const isAkordaCommentIcon = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_IMAGE]);
 };

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2223,9 +2223,7 @@ class InlineChangeEditor {
         const isParentAComment = isAkordaComment(parent);
         // Check if it is deleting the first character from the comment
         const isDeletingElementBeginning = cInd === 0 && isParentAComment;
-        // Check if it is deleting the last character from the comment
-        const isDeletingElementEnding = cInd >= nChildren - 1 && isParentAComment;
-        if (isDeletingElementBeginning || isDeletingElementEnding) {
+        if (isParentAComment) {
           // Copy comment attributes to new 'del' element
           copyCommentData(parent, ctNode);
           // Condition to be sure is what we want

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2242,16 +2242,15 @@ class InlineChangeEditor {
             dom.insertAfter(contentAddNode, ctNode);
           }
         } else {
-          if (cInd > 0 && cInd >= nChildren - 1) {
+          if (cInd > 0 && cInd >= nChildren - 1 && parent.isEqualNode(contentAddNode)) {
             dom.insertAfter(contentAddNode, ctNode);
           } else {
-            if (cInd >= 0) {
+            if (cInd > 0 || nChildren > 0) {
               const splitNode = this._splitNode(contentAddNode, parent, cInd);
               this._deleteEmptyNode(splitNode);
             }
             contentAddNode.parentNode.insertBefore(ctNode, contentAddNode);
           }
-          this._deleteEmptyNode(contentAddNode);
         }
 
         const bookmarkStart: any = getBookmarkStart(contentAddNode.parentNode);

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2254,8 +2254,8 @@ class InlineChangeEditor {
                 }
               } else {
                 // The parent node is an element
-                // We needs this code to keep the elements structure and herarchy
-                // the elements are splitted but at least the text keep the formatting
+                // We need this code to keep the elements structure and hierarchy
+                // the elements are splitted but at least the text keeps the formatting
                 splitNode = this._splitNode(contentAddNode, parent, cInd);
                 this._deleteEmptyNode(splitNode);
                 // Prepend or append the delete node in its parent
@@ -2275,8 +2275,8 @@ class InlineChangeEditor {
             splitNode = this._splitNode(contentAddNode, parent, cInd);
             this._deleteEmptyNode(splitNode);
           }
-          // The parent is an element prepend or append the delete node in its parent
-          if (isParentElement) {
+          // The parent is an element and not a comment to prepend or append the delete node
+          if (isParentElement && !isParentAComment) {
             parent.prepend(ctNode);
           } else {
             //Default behavior

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2221,11 +2221,10 @@ class InlineChangeEditor {
 
         // Check if it is a comment marker element
         const isParentAComment = isAkordaComment(parent);
-
         // Check if it is deleting the first character from the comment
-        const isDeletingElementBeginning = cInd === 0;
+        const isDeletingElementBeginning = cInd === 0 && isParentAComment;
         // Check if it is deleting the last character from the comment
-        const isDeletingElementEnding = cInd >= nChildren - 1;
+        const isDeletingElementEnding = cInd >= nChildren - 1 && isParentAComment;
         let splitNode;
         if (isDeletingElementBeginning || isDeletingElementEnding) {
           if (isParentAComment) {
@@ -2234,39 +2233,23 @@ class InlineChangeEditor {
           }
           // Condition to be sure is what we want
           if (contentAddNode.contains(parent)) {
-            // Check if the parent element is a comment
-            if (isParentAComment) {
-              if (isDeletingElementBeginning) {
-                // Insert the new 'del' element at the beginning
-                dom.insertBefore(parent, ctNode);
-              } else {
-                // Insert the new 'del' element at the end
-                dom.insertAfter(parent, ctNode);
-              }
+            if (isDeletingElementBeginning) {
+              // Insert the new 'del' element at the beginning
+              dom.insertBefore(parent, ctNode);
             } else {
-              // Prepend or append the delete node in its parent
-              if (isDeletingElementBeginning) {
-                parent.prepend(ctNode);
-              } else {
-                parent.appendChild(ctNode);
-              }
+              // Insert the new 'del' element at the end
+              dom.insertAfter(parent, ctNode);
             }
           } else {
             // Default behavior
             dom.insertAfter(contentAddNode, ctNode);
           }
         } else {
-          if (cInd > 0) {
+          if (cInd >= 0) {
             splitNode = this._splitNode(contentAddNode, parent, cInd);
             this._deleteEmptyNode(splitNode);
           }
-          // The parent is an element and not a comment to prepend or append the delete node
-          if (!isParentAComment) {
-            parent.prepend(ctNode);
-          } else {
-            //Default behavior
-            contentAddNode.parentNode.insertBefore(ctNode, contentAddNode);
-          }
+          contentAddNode.parentNode.insertBefore(ctNode, contentAddNode);
         }
 
         const bookmarkStart: any = getBookmarkStart(contentAddNode.parentNode);

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2221,54 +2221,39 @@ class InlineChangeEditor {
 
         // Check if it is a comment marker element
         const isParentAComment = isAkordaComment(parent);
-        // Check if it is a element
-        const isParentElement = isNodeElement(parent);
+
         // Check if it is deleting the first character from the comment
-        const isDeletingElementBeginning = cInd === 0 && isParentElement;
+        const isDeletingElementBeginning = cInd === 0;
         // Check if it is deleting the last character from the comment
-        const isDeletingElementEnding = cInd >= nChildren - 1 && isParentElement;
+        const isDeletingElementEnding = cInd >= nChildren - 1;
         let splitNode;
-        if (
-          (cInd > 0 && cInd >= nChildren - 1) ||
-          isDeletingElementBeginning ||
-          isDeletingElementEnding
-        ) {
-          if (!isDeletingElementBeginning && !isDeletingElementEnding) {
-            // Default behavior
-            dom.insertAfter(contentAddNode, ctNode);
-          } else {
-            if (isParentElement) {
-              // Copy comment attributes to new 'del' element
-              copyCommentData(parent, ctNode);
-            }
-            // Condition to be sure is what we want
-            if (contentAddNode.contains(parent)) {
-              // Check if the parent element is a comment
-              if (isParentAComment) {
-                if (isDeletingElementBeginning) {
-                  // Insert the new 'del' element at the beginning
-                  dom.insertBefore(parent, ctNode);
-                } else {
-                  // Insert the new 'del' element at the end
-                  dom.insertAfter(parent, ctNode);
-                }
+        if (isDeletingElementBeginning || isDeletingElementEnding) {
+          if (isParentAComment) {
+            // Copy comment attributes to new 'del' element
+            copyCommentData(parent, ctNode);
+          }
+          // Condition to be sure is what we want
+          if (contentAddNode.contains(parent)) {
+            // Check if the parent element is a comment
+            if (isParentAComment) {
+              if (isDeletingElementBeginning) {
+                // Insert the new 'del' element at the beginning
+                dom.insertBefore(parent, ctNode);
               } else {
-                // The parent node is an element
-                // We need this code to keep the elements structure and hierarchy
-                // the elements are splitted but at least the text keeps the formatting
-                splitNode = this._splitNode(contentAddNode, parent, cInd);
-                this._deleteEmptyNode(splitNode);
-                // Prepend or append the delete node in its parent
-                if (isDeletingElementBeginning) {
-                  parent.prepend(ctNode);
-                } else {
-                  parent.appendChild(ctNode);
-                }
+                // Insert the new 'del' element at the end
+                dom.insertAfter(parent, ctNode);
               }
             } else {
-              // Default behavior
-              dom.insertAfter(contentAddNode, ctNode);
+              // Prepend or append the delete node in its parent
+              if (isDeletingElementBeginning) {
+                parent.prepend(ctNode);
+              } else {
+                parent.appendChild(ctNode);
+              }
             }
+          } else {
+            // Default behavior
+            dom.insertAfter(contentAddNode, ctNode);
           }
         } else {
           if (cInd > 0) {
@@ -2276,7 +2261,7 @@ class InlineChangeEditor {
             this._deleteEmptyNode(splitNode);
           }
           // The parent is an element and not a comment to prepend or append the delete node
-          if (isParentElement && !isParentAComment) {
+          if (!isParentAComment) {
             parent.prepend(ctNode);
           } else {
             //Default behavior
@@ -2286,10 +2271,10 @@ class InlineChangeEditor {
 
         const bookmarkStart: any = getBookmarkStart(contentAddNode.parentNode);
         const bookmarkEnd: any = getBookmarkEnd(contentAddNode.parentNode);
-        const commentStart: any = isParentElement && getCommentStart(this.element, parent);
-        const commentEnd: any = isParentElement && getCommentEnd(this.element, parent);
+        const commentStart: any = isParentAComment && getCommentStart(this.element, parent);
+        const commentEnd: any = isParentAComment && getCommentEnd(this.element, parent);
         const repositionCommentsTags: boolean =
-          isParentElement &&
+          isParentAComment &&
           !!bookmarkStart &&
           ((!!commentStart && commentStart.offsetLeft >= bookmarkStart.offsetLeft) ||
             (!!commentEnd && commentEnd.offsetLeft >= bookmarkEnd.offsetLeft));
@@ -2302,7 +2287,7 @@ class InlineChangeEditor {
         }
         if (repositionCommentsTags) {
           if (
-            isParentElement &&
+            isParentAComment &&
             (isAkordaComment(ctNode.nextElementSibling) ||
               isFirstElementAComment(ctNode.nextElementSibling))
           ) {

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2226,10 +2226,8 @@ class InlineChangeEditor {
         // Check if it is deleting the last character from the comment
         const isDeletingElementEnding = cInd >= nChildren - 1 && isParentAComment;
         if (isDeletingElementBeginning || isDeletingElementEnding) {
-          if (isParentAComment) {
-            // Copy comment attributes to new 'del' element
-            copyCommentData(parent, ctNode);
-          }
+          // Copy comment attributes to new 'del' element
+          copyCommentData(parent, ctNode);
           // Condition to be sure is what we want
           if (contentAddNode.contains(parent)) {
             if (isDeletingElementBeginning) {
@@ -2244,11 +2242,16 @@ class InlineChangeEditor {
             dom.insertAfter(contentAddNode, ctNode);
           }
         } else {
-          if (cInd >= 0) {
-            const splitNode = this._splitNode(contentAddNode, parent, cInd);
-            this._deleteEmptyNode(splitNode);
+          if (cInd > 0 && cInd >= nChildren - 1) {
+            dom.insertAfter(contentAddNode, ctNode);
+          } else {
+            if (cInd >= 0) {
+              const splitNode = this._splitNode(contentAddNode, parent, cInd);
+              this._deleteEmptyNode(splitNode);
+            }
+            contentAddNode.parentNode.insertBefore(ctNode, contentAddNode);
           }
-          contentAddNode.parentNode.insertBefore(ctNode, contentAddNode);
+          this._deleteEmptyNode(contentAddNode);
         }
 
         const bookmarkStart: any = getBookmarkStart(contentAddNode.parentNode);

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -18,7 +18,6 @@ import {
   getCommentStart,
   getCommentEnd,
   ensureMillsecondsTimestamp,
-  isNodeElement,
 } from './akorda';
 
 const ice: any = {};

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -18,6 +18,7 @@ import {
   getCommentStart,
   getCommentEnd,
   ensureMillsecondsTimestamp,
+  isNodeElement,
 } from './akorda';
 
 const ice: any = {};
@@ -2219,28 +2220,28 @@ class InlineChangeEditor {
         ctNode.appendChild(contentNode);
 
         // Check if it is a comment marker element
-        const isParentAComment = isAkordaComment(parent);
+        const isParentElement = isNodeElement(parent);
         // Check if it is deleting the first character from the comment
-        const isDeletingCommentBeginning = cInd === 0 && isParentAComment;
+        const isDeletingElementBeginning = cInd === 0;
         // Check if it is deleting the last character from the comment
-        const isDeletingCommentEnding = cInd >= nChildren - 1 && isParentAComment;
+        const isDeletingElementEnding = cInd >= nChildren - 1;
 
         if (
           (cInd > 0 && cInd >= nChildren - 1) ||
-          isDeletingCommentBeginning ||
-          isDeletingCommentEnding
+          isDeletingElementBeginning ||
+          isDeletingElementEnding
         ) {
-          if (!isDeletingCommentBeginning && !isDeletingCommentEnding) {
+          if (!isDeletingElementBeginning && !isDeletingElementEnding) {
             // Default behavior
             dom.insertAfter(contentAddNode, ctNode);
           } else {
-            if (isParentAComment) {
+            if (isParentElement) {
               // Copy comment attributes to new 'del' element
               copyCommentData(parent, ctNode);
             }
             // Condition to be sure is what we want
             if (contentAddNode.contains(parent)) {
-              if (isDeletingCommentBeginning) {
+              if (isDeletingElementBeginning) {
                 // Insert the new 'del' element at the beginning
                 dom.insertBefore(parent, ctNode);
               } else {
@@ -2262,10 +2263,10 @@ class InlineChangeEditor {
 
         var bookmarkStart: any = getBookmarkStart(contentAddNode.parentNode);
         var bookmarkEnd: any = getBookmarkEnd(contentAddNode.parentNode);
-        var commentStart: any = isParentAComment && getCommentStart(this.element, parent);
-        var commentEnd: any = isParentAComment && getCommentEnd(this.element, parent);
+        var commentStart: any = isParentElement && getCommentStart(this.element, parent);
+        var commentEnd: any = isParentElement && getCommentEnd(this.element, parent);
         var repositionCommentsTags: boolean =
-          isParentAComment &&
+          isParentElement &&
           !!bookmarkStart &&
           ((!!commentStart && commentStart.offsetLeft >= bookmarkStart.offsetLeft) ||
             (!!commentEnd && commentEnd.offsetLeft >= bookmarkEnd.offsetLeft));
@@ -2278,7 +2279,7 @@ class InlineChangeEditor {
         }
         if (repositionCommentsTags) {
           if (
-            isParentAComment &&
+            isParentElement &&
             (isAkordaComment(ctNode.nextElementSibling) ||
               isFirstElementAComment(ctNode.nextElementSibling))
           ) {

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2225,7 +2225,6 @@ class InlineChangeEditor {
         const isDeletingElementBeginning = cInd === 0 && isParentAComment;
         // Check if it is deleting the last character from the comment
         const isDeletingElementEnding = cInd >= nChildren - 1 && isParentAComment;
-        let splitNode;
         if (isDeletingElementBeginning || isDeletingElementEnding) {
           if (isParentAComment) {
             // Copy comment attributes to new 'del' element
@@ -2246,7 +2245,7 @@ class InlineChangeEditor {
           }
         } else {
           if (cInd >= 0) {
-            splitNode = this._splitNode(contentAddNode, parent, cInd);
+            const splitNode = this._splitNode(contentAddNode, parent, cInd);
             this._deleteEmptyNode(splitNode);
           }
           contentAddNode.parentNode.insertBefore(ctNode, contentAddNode);


### PR DESCRIPTION
## Issue before the fix
The is an issue when the user tries to delete a content of a nested element when is inside of an insert element, the content is move outside of the insert element. We made a fix in the past to not do that with the comments but it can happen with other can of inline elements like `b`.

## What changed
* Changed the logic _addDeletionInInsertNode to consider elements which are not .marker-comment to append or prepend the delete node. 

## Notes
We need to be careful  with the changes, I tried to change less as possible to not create side effects.