### PR TITLE
fix: delete in insert - comments and content elements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,18 +11,17 @@ const App: React.FC = () => {
           extraPlugins: 'liter',
           lite: {
             userId: 191,
-            userName: 'Matt Meiske'
-          }
+            userName: 'Matt Meiske',
+          },
         }}
         data={`<div>
-          <p>hello world</p>
-          <p>
-            one two three
-            <span class="comment-start"></span> testing <span></span>
-            <span class="comment-end"></span>
-            four fix six
-          </p>
-        <div>`}
+        <p>
+        <ins data-id="1" class="ice-ins ice-cts-2"><span>The quick <b>brown</b> fox <i>jumps</i> over the lazy dog</span></ins>
+        </p>
+        <p>
+          Text before ins <ins data-id="1" class="ice-ins ice-cts-2"><span data-last-name="meiske">The comment starts here→<span data-w-id="1" data-track-changes-ignore="true" cke-editable="false" unselectable="true" contenteditable="false" start="true" class="comment-marker comment-start"></span><span data-c-id="s1 " class="marker-comment" removable="true">I am a comment</span><img data-c-id="i1" class="marker-image" src="/assets/src/media/img/font-comment.png?440e7fee" data-track-changes-ignore="true" data-cke-real-element-type="annotation" cke-editable="false" contenteditable="false"><span data-w-id="1" data-track-changes-ignore="true" cke-editable="false" contenteditable="false" end="true" class="comment-end comment-marker"></span>←and ends there.</span></ins> Text after ins
+        </p>
+      <div>`}
         onBeforeLoad={(CKEDITOR: any) => {
           CKEDITOR.disableAutoInline = true;
           CKEDITOR.dtd.$removeEmpty.ins = 0;

--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -64,10 +64,6 @@ export const isAkordaComment = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_COMMENT]);
 };
 
-export const isNodeElement = (node: Node): boolean => {
-  return node.nodeType === Node.ELEMENT_NODE;
-};
-
 export const isAkordaCommentIcon = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_IMAGE]);
 };

--- a/src/plugins/lite/akorda.ts
+++ b/src/plugins/lite/akorda.ts
@@ -64,6 +64,10 @@ export const isAkordaComment = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_COMMENT]);
 };
 
+export const isNodeElement = (node: Node): boolean => {
+  return node.nodeType === Node.ELEMENT_NODE;
+};
+
 export const isAkordaCommentIcon = (node: Node): boolean => {
   return hasClassFrom(node, [AKORDA_CLASS_NAMES.MARKER_IMAGE]);
 };

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2,24 +2,7 @@ import rangy from 'rangy';
 import dom from './dom';
 import Selection from './selection';
 import Bookmark from './bookmark';
-import {
-  isAkordaMarkerElement,
-  isAkordaUnselectable,
-  isAkordaComment,
-  isFirstElementAComment,
-  copyCommentData,
-  isAkordaCommentStartMarker,
-  isAkordaCommentEndMarker,
-  insertCommentStartBefore,
-  insertCommentEndAfter,
-  isBookmarkStart,
-  getBookmarkStart,
-  getBookmarkEnd,
-  getCommentStart,
-  getCommentEnd,
-  ensureMillsecondsTimestamp,
-  isNodeElement,
-} from './akorda';
+import { isAkordaMarkerElement, isAkordaUnselectable, ensureMillsecondsTimestamp } from './akorda';
 
 const ice: any = {};
 

--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -18,6 +18,7 @@ import {
   getCommentStart,
   getCommentEnd,
   ensureMillsecondsTimestamp,
+  isNodeElement,
 } from './akorda';
 
 const ice: any = {};
@@ -150,13 +151,18 @@ class InlineChangeEditor {
   _showingTips: any;
   _domObserverTimeout: any;
   _domObserver: any; // don't think this is used (meiske)
+  editor: any;
 
   constructor(options: any) {
     options || (options = {});
     if (!options.element) {
       throw new Error('options.element must be defined for ice construction.');
     }
+    if (!options.editor) {
+      throw new Error('options.editor must be defined for ice construction');
+    }
     this.element = options.element;
+    this.editor = options.editor;
     this._changes = {};
     // Tracks all of the styles for users according to the following model:
     //	[userId] => styleId; where style is "this.stylePrefix" + "this.uniqueStyleIndex"
@@ -2210,108 +2216,54 @@ class InlineChangeEditor {
         parent = contentNode.parentNode,
         nChildren = parent.childNodes.length,
         ctNode;
-      if (!isAkordaMarkerElement(contentNode)) {
-        parent.removeChild(contentNode);
-        ctNode = this._createIceNode(DELETE_TYPE);
-        if (options.deleteNodesCollection) {
-          options.deleteNodesCollection.push(ctNode);
-        }
+
+      const isParentTheInsert = parent.isEqualNode(contentAddNode);
+
+      ctNode = this._createIceNode(DELETE_TYPE);
+      if (options.deleteNodesCollection) {
+        options.deleteNodesCollection.push(ctNode);
+      }
+      parent.removeChild(contentNode);
+      if (isParentTheInsert) {
         ctNode.appendChild(contentNode);
-
-        // Check if it is a comment marker element
-        const isParentAComment = isAkordaComment(parent);
-        // Check if it is deleting the first character from the comment
-        const isDeletingCommentBeginning = cInd === 0 && isParentAComment;
-        // Check if it is deleting the last character from the comment
-        const isDeletingCommentEnding = cInd >= nChildren - 1 && isParentAComment;
-
-        if (
-          (cInd > 0 && cInd >= nChildren - 1) ||
-          isDeletingCommentBeginning ||
-          isDeletingCommentEnding
-        ) {
-          if (!isDeletingCommentBeginning && !isDeletingCommentEnding) {
-            // Default behavior
-            dom.insertAfter(contentAddNode, ctNode);
-          } else {
-            if (isParentAComment) {
-              // Copy comment attributes to new 'del' element
-              copyCommentData(parent, ctNode);
-            }
-            // Condition to be sure is what we want
-            if (contentAddNode.contains(parent)) {
-              if (isDeletingCommentBeginning) {
-                // Insert the new 'del' element at the beginning
-                dom.insertBefore(parent, ctNode);
-              } else {
-                // Insert the new 'del' element at the end
-                dom.insertAfter(parent, ctNode);
-              }
-            } else {
-              // Default behavior
-              dom.insertAfter(contentAddNode, ctNode);
-            }
-          }
-        } else {
-          if (cInd > 0) {
-            var splitNode = this._splitNode(contentAddNode, parent, cInd);
-            this._deleteEmptyNode(splitNode);
-          }
-          contentAddNode.parentNode.insertBefore(ctNode, contentAddNode);
+      } else {
+        const clonedParent = parent.cloneNode();
+        clonedParent.appendChild(contentNode);
+        ctNode.appendChild(clonedParent);
+      }
+      if (isParentTheInsert && cInd > 0 && cInd >= nChildren - 1) {
+        dom.insertAfter(contentAddNode, ctNode);
+      } else {
+        if (cInd > 0 || !isParentTheInsert) {
+          var splitNode = this._splitNode(contentAddNode, parent, cInd);
+          this._deleteEmptyNode(splitNode);
         }
+        contentAddNode.parentNode.insertBefore(ctNode, contentAddNode);
+      }
+      // find the comment marker and move it before assessing _deleteEmptyNode
+      if (dom.hasNoTextOrStubContent(contentAddNode)) {
+        const commentMarker = contentAddNode.querySelector('.comment-marker');
+        if (!!commentMarker) {
+          commentMarker.parentNode.remove(commentMarker);
+          contentAddNode.parentNode.insertBefore(commentMarker, contentAddNode);
+        }
+      }
+      this._deleteEmptyNode(contentAddNode);
 
-        var bookmarkStart: any = getBookmarkStart(contentAddNode.parentNode);
-        var bookmarkEnd: any = getBookmarkEnd(contentAddNode.parentNode);
-        var commentStart: any = isParentAComment && getCommentStart(this.element, parent);
-        var commentEnd: any = isParentAComment && getCommentEnd(this.element, parent);
-        var repositionCommentsTags: boolean =
-          isParentAComment &&
-          !!bookmarkStart &&
-          ((!!commentStart && commentStart.offsetLeft >= bookmarkStart.offsetLeft) ||
-            (!!commentEnd && commentEnd.offsetLeft >= bookmarkEnd.offsetLeft));
-
-        this._deleteEmptyNode(contentAddNode);
-        if (range && moveLeft) {
-          range.setStartBefore(ctNode);
-          range.collapse(true);
-          this.selection.addRange(range);
-        }
-        if (repositionCommentsTags) {
-          if (
-            isParentAComment &&
-            (isAkordaComment(ctNode.nextElementSibling) ||
-              isFirstElementAComment(ctNode.nextElementSibling))
-          ) {
-            copyCommentData(parent, ctNode);
-          }
-          var nextElementSibling = ctNode.nextElementSibling;
-          if (!!nextElementSibling && isAkordaCommentStartMarker(nextElementSibling.children[1])) {
-            insertCommentStartBefore(nextElementSibling.children[1], ctNode);
-          } else if (
-            !!nextElementSibling &&
-            isAkordaCommentStartMarker(nextElementSibling.children[0])
-          ) {
-            insertCommentStartBefore(nextElementSibling.children[0], ctNode);
-          } else {
-            let previousSibling = ctNode.previousElementSibling;
-            if (
-              !!previousSibling &&
-              !!previousSibling.firstChild &&
-              isAkordaCommentStartMarker(previousSibling.firstChild) &&
-              (isBookmarkStart(previousSibling.firstChild.nextElementSibling) ||
-                isBookmarkStart(previousSibling.firstChild.nextElementSibling.firstChild))
-            ) {
-              insertCommentStartBefore(previousSibling.firstChild, ctNode);
-            }
-          }
-          var previousSibling = ctNode.previousElementSibling;
-          if (!!previousSibling && isAkordaCommentEndMarker(previousSibling.lastChild)) {
-            insertCommentEndAfter(previousSibling.lastChild, ctNode);
-          }
-        }
-        if (options && options.merge) {
-          this._mergeDeleteNode(ctNode);
-        }
+      if (range && moveLeft) {
+        range.setStartBefore(ctNode);
+        range.collapse(true);
+        this.selection.addRange(range);
+      }
+      if (options && options.merge) {
+        this._mergeDeleteNode(ctNode);
+        const toNormalize = new CKEDITOR.dom.element(ctNode);
+        toNormalize
+          .getChildren()
+          .toArray()
+          .forEach((child: any) => {
+            !!child.mergeSiblings && child.mergeSiblings(false);
+          });
       }
       if (range) {
         range.refresh();

--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -1072,6 +1072,7 @@ LITEPlugin.prototype = {
       return;
     }
     var iceprops: any = {
+      editor: this._editor,
       styleColorsNumber: 1,
       element: body,
       mergeBlocks: false,


### PR DESCRIPTION
If we had the following content
```
<ins data-id="1" class="ice-ins ice-cts-2"><span>The quick <b>brown</b> fox <i>jumps</i> over the lazy dog</span></ins>
```
Deleting inside this insert would cause the cursor to jump at the formatted content (b, i).

* If the cursor was placed just before the `s` in `<i>jumps</i>` and backspace/delete key was pressed, the cursor would jump to the end of the `ins`.
* If the cursor was placed after the `b` in `<b>brown</b>` and the backspace/delete key was pressed, the cursor would jump (along with the `b` character) to the beginning of the insert.

It appears that the original code assumed that the parent of the deleted character was always the `<ins>`.

The modifications here ensure that we always split if the parent of the deleted character is not the insert. Additional logic was added to account closing the parent node of the deleted character (if it's not the insert) so that we retain the wrapping tag (e.g., `b`, or `i`, or `span`). And then added the ckeditor editor instance so that we can use `mergeSiblings` to clean up the resulting dom structure after the deletion occurs.

Also, removed much of the original Akorda comment handling since it was primarily accounting for the strange lite plugin behavior that is fixed by this ticket. We do, however, make a check to ensure that comments are moved empty content nodes before they might be deleted.
