### PR TITLE
fix: support reverting ins after rejection

### DIFF
--- a/src/plugins/lite/ice.ts
+++ b/src/plugins/lite/ice.ts
@@ -2185,7 +2185,7 @@ class InlineChangeEditor {
 
       // When deleting inside another user's insert, we want to retain the original insert
       // details so that we can revert (cf REVERT_MY_CHANGE command)
-      const insertAttributes = new CKEDITOR.dom.element(contentAddNode).getAttributes(['data-id']);
+      const insertAttributes = new CKEDITOR.dom.element(contentAddNode).getAttributes();
       ctNode.dataset.akordaRevertInfo = JSON.stringify(insertAttributes);
 
       parent.removeChild(contentNode);


### PR DESCRIPTION
## Issue before fix
* We need to account for rejection of a change, then reverting the result. Rejecting a change will produce a new tracked change in Akorda, so that "revert" should go back to the previous tracked change.

## What changed
* Reworked the `_onRevertMyChange` func to simplify and allow reverting of inserts that have revert-info atttr.