### PR TITLE
fix: nested change color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akordacorp/liter",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Akorda LITEr track changes for CKEditor",
   "license": "GPL-2.0-only",
   "main": "index.js",

--- a/src/plugins/lite/plugin.scss
+++ b/src/plugins/lite/plugin.scss
@@ -7,10 +7,8 @@
   }
 
   .ice-ins.ice-cts-#{$styleId},
-  .ice-ins.ice-cts-#{$styleId} *,
   .cont-cts-#{$styleId},
-  .ice-del.ice-cts-#{$styleId},
-  .ice-del.ice-cts-#{$styleId} * {
+  .ice-del.ice-cts-#{$styleId} {
     color: $color;
   }
 
@@ -54,9 +52,9 @@ del.ice-no-decoration {
 
   @include trackedChangeStyle('0', #0174ca);
   @include trackedChangeStyle('1', #e3495d);
-  @include trackedChangeStyle('2', #f000ff);
-  @include trackedChangeStyle('3', #f3b83b);
-  @include trackedChangeStyle('4', #51af46);
-  @include trackedChangeStyle('5', #61dafb);
-  @include trackedChangeStyle('6', #c87022);
+  @include trackedChangeStyle('2', #51af46);
+  @include trackedChangeStyle('3', #61dafb);
+  @include trackedChangeStyle('4', #c87022);
+  @include trackedChangeStyle('5', #f3b83b);
+  @include trackedChangeStyle('6', #f000ff);
 }


### PR DESCRIPTION
## Issue before fix
* A nested delete inside of an insert can sometimes take on the color of the parent insert because of the wildcard selector (*).
* Color for user #2 was a pink/purple, and a little intense.

## What changed
* Removed wildcard selector for user colors in tracked changes
* Moved the colors around a bit so that pink/puple is for user #6 and not #2. Moved green to be #2.