### PR TITLE
fix: key event handler

### DIFF
--- a/src/plugins/lite/plugin.ts
+++ b/src/plugins/lite/plugin.ts
@@ -1201,7 +1201,10 @@ LITEPlugin.prototype = {
                   return event ? this._tracker.handleEvent(event) : true;
                 }
                 return true;
-              }.bind(this)
+              }.bind(this),
+              null,
+              null,
+              9
             )
           );
         }


### PR DESCRIPTION
## Issue before fix
* When an entire list is selected and deleted, the LITE key handler is never called, resulting in no tracked changes for the deletion. This is due to another event handler canceling the event before the LITE plugin can process it.

## What changed
* Adjusted the priority of the LITE key event handler to ensure it is run before the handler that cancels it.